### PR TITLE
Fix iOS blank web view on resume

### DIFF
--- a/HybridWebView/Platforms/iOS/HybridWebView.iOS.cs
+++ b/HybridWebView/Platforms/iOS/HybridWebView.iOS.cs
@@ -1,6 +1,7 @@
 ﻿using Foundation;
 using UIKit;
 using WebKit;
+using Microsoft.Maui.Controls;
 
 namespace HybridWebView
 {
@@ -13,9 +14,20 @@ namespace HybridWebView
 
         private WKWebView PlatformWebView => (WKWebView)Handler!.PlatformView!;
 
+        private NSObject? _didBecomeActiveObserver;
+
         private partial Task InitializeHybridWebView()
         {
+            _didBecomeActiveObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.DidBecomeActiveNotification, HandleDidBecomeActive);
             return Task.CompletedTask;
+        }
+
+        private void HandleDidBecomeActive(NSNotification notification)
+        {
+            if (PlatformWebView.Url == null || PlatformWebView.Url.AbsoluteString == "about:blank")
+            {
+                Microsoft.Maui.Controls.Device.BeginInvokeOnMainThread(() => Navigate(StartPath));
+            }
         }
 
         private partial void NavigateCore(string url)
@@ -48,6 +60,13 @@ namespace HybridWebView
             //        _cookieDomains[domain.Key] = domain.Value - 1;
             //    }
             //}
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _didBecomeActiveObserver?.Dispose();
+            _didBecomeActiveObserver = null;
         }
     }
 }


### PR DESCRIPTION
## Summary
- reload iOS web view when the app resumes to avoid a blank page

## Testing
- `dotnet build` *(fails: `dotnet` not found)*